### PR TITLE
Fix copy mode to wait for user input

### DIFF
--- a/lib/ebook_reader/reader.rb
+++ b/lib/ebook_reader/reader.rb
@@ -217,7 +217,7 @@ module EbookReader
     def enter_copy_mode
       @copy_mode = true
       draw_screen
-      Terminal.read_key
+      Terminal.read_key_blocking
     ensure
       @copy_mode = false
       draw_screen

--- a/lib/ebook_reader/terminal.rb
+++ b/lib/ebook_reader/terminal.rb
@@ -158,6 +158,15 @@ module EbookReader
         nil # No input available
       end
 
+      def read_key_blocking
+        loop do
+          key = read_key
+          return key if key
+
+          IO.select([$stdin])
+        end
+      end
+
       private
 
       def setup_signal_handlers

--- a/spec/reader_copy_mode_spec.rb
+++ b/spec/reader_copy_mode_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe EbookReader::Reader, 'copy mode' do
   end
 
   it 'shows the indicator and waits for input' do
-    allow(EbookReader::Terminal).to receive(:read_key).and_return('x')
+    allow(EbookReader::Terminal).to receive(:read_key_blocking).and_return('x')
     expect(EbookReader::Terminal).to receive(:write).with(24, 1, /copy mode activated!/i)
     reader.enter_copy_mode
     expect(reader.instance_variable_get(:@copy_mode)).to be false


### PR DESCRIPTION
## Summary
- keep reader in copy mode until a key is pressed
- expose `Terminal.read_key_blocking` and use it in copy mode
- adjust tests for new behavior

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_6886cf3340a4832ba795629ba7025792