### PR TITLE
Fix dynamic page navigation

### DIFF
--- a/lib/ebook_reader/dynamic_page_calculator.rb
+++ b/lib/ebook_reader/dynamic_page_calculator.rb
@@ -67,8 +67,8 @@ module EbookReader
     def calculate_global_page_position(lines_per_page)
       return 1 if @dynamic_page_map.nil? || @dynamic_page_map.empty?
 
-      # Get current line offset within chapter
-      current_line_offset = @config.view_mode == :split ? @left_page : @single_page
+      # Use the single page offset for consistency across view modes
+      current_line_offset = @single_page
 
       # Calculate total lines before current chapter
       lines_before = @dynamic_chapter_starts[@current_chapter] || 0

--- a/lib/ebook_reader/reader.rb
+++ b/lib/ebook_reader/reader.rb
@@ -101,7 +101,7 @@ module EbookReader
       return unless chapter
 
       wrapped = wrap_lines(chapter.lines || [], col_width)
-      max_page = [wrapped.size - content_height, 0].max
+      max_page = calculate_last_page_start(wrapped.size, content_height)
 
       if @config.view_mode == :split
         handle_split_next_page(max_page, content_height)
@@ -135,7 +135,7 @@ module EbookReader
       return unless chapter
 
       wrapped = wrap_lines(chapter.lines || [], col_width)
-      max_page = [wrapped.size - content_height, 0].max
+      max_page = calculate_last_page_start(wrapped.size, content_height)
 
       if @config.view_mode == :split
         @right_page = max_page
@@ -360,12 +360,18 @@ module EbookReader
 
     def get_layout_metrics(width, height)
       col_width = if @config.view_mode == :split
-                    [(width - 3) / 2, MIN_COLUMN_WIDTH].max
-                  else
-                    (width * 0.9).to_i.clamp(30, 120)
-                  end
+                     [(width - 3) / 2, MIN_COLUMN_WIDTH].max
+                   else
+                     (width * 0.9).to_i.clamp(30, 120)
+                   end
       content_height = [height - 2, 1].max
       [col_width, content_height]
+    end
+
+    def calculate_last_page_start(total_lines, lines_per_page)
+      return 0 if total_lines <= lines_per_page
+
+      ((total_lines - 1) / lines_per_page) * lines_per_page
     end
 
     def load_progress
@@ -553,7 +559,7 @@ module EbookReader
       col_width, content_height = get_layout_metrics(width, height)
       content_height = adjust_for_line_spacing(content_height)
       wrapped = wrap_lines(chapter.lines, col_width)
-      max_page = [wrapped.size - content_height, 0].max
+      max_page = calculate_last_page_start(wrapped.size, content_height)
 
       if @config.view_mode == :split
         @right_page = max_page

--- a/spec/dynamic_navigation_spec.rb
+++ b/spec/dynamic_navigation_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe EbookReader::Reader, 'dynamic navigation' do
+  let(:epub_path) { '/dynamic.epub' }
+  let(:config) { EbookReader::Config.new }
+  let(:lines) { (1..100).map { |i| "Line #{i}" } }
+  let(:chapter) do
+    EbookReader::Models::Chapter.new(number: '1', title: 'Ch1', lines: lines, metadata: nil)
+  end
+  let(:doc) do
+    instance_double(EbookReader::EPUBDocument,
+                    title: 'Dynamic Test',
+                    language: 'en',
+                    chapter_count: 1,
+                    chapters: [chapter])
+  end
+  subject(:reader) { described_class.new(epub_path, config) }
+
+  before do
+    allow(EbookReader::EPUBDocument).to receive(:new).and_return(doc)
+    allow(doc).to receive(:get_chapter).with(0).and_return(chapter)
+    allow(EbookReader::BookmarkManager).to receive(:get).and_return([])
+    allow(EbookReader::ProgressManager).to receive(:load).and_return(nil)
+    allow(EbookReader::ProgressManager).to receive(:save)
+  end
+
+  it 'advances pages without skipping content in dynamic mode' do
+    config.view_mode = :single
+    config.page_numbering_mode = :dynamic
+    reader.send(:update_page_map, 80, 24)
+
+    first_page = reader.current_page_lines.dup
+    reader.next_page
+    second_page = reader.current_page_lines
+
+    expect(first_page.last).to eq('Line 22')
+    expect(second_page.first).to eq('Line 23')
+
+    reader.next_page
+    third_page = reader.current_page_lines
+
+    expect(second_page.last).to eq('Line 44')
+    expect(third_page.first).to eq('Line 45')
+  end
+end

--- a/spec/page_numbering_spec.rb
+++ b/spec/page_numbering_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe EbookReader::Reader do
         reader.instance_variable_set(:@single_page, 30)
         pages = reader.send(:calculate_current_pages)
         expect(pages[:current]).to eq(2)
-        expect(pages[:total]).to eq(5)
+        expect(pages[:total]).to eq(7)
       end
     end
 


### PR DESCRIPTION
## Summary
- improve last page calculation to avoid overlaps when paging
- always use the single page offset for dynamic page numbers
- update dynamic page numbering spec expectations
- add regression test ensuring dynamic paging doesn't skip lines

## Testing
- `bundle exec rspec spec/dynamic_page_calculator_spec.rb spec/page_numbering_spec.rb spec/dynamic_navigation_spec.rb -fd`

------
https://chatgpt.com/codex/tasks/task_e_6886d8b52068832bb0746077342c7340