### PR TITLE
Fix terminal mouse patch and add annotation tests

### DIFF
--- a/lib/ebook_reader/reader_modes/annotation_editor_mode.rb
+++ b/lib/ebook_reader/reader_modes/annotation_editor_mode.rb
@@ -9,8 +9,8 @@ module EbookReader
       def initialize(reader, text: nil, range: nil, annotation: nil, chapter_index: nil)
         super(reader)
         @annotation = annotation
-        @selected_text = text || annotation&.fetch('text', '')
-        @note = annotation&.fetch('note', '') || ''
+        @selected_text = (text || annotation&.fetch('text', '') || '').dup
+        @note = (annotation&.fetch('note', '') || '').dup
         @range = range || annotation&.fetch('range')
         @chapter_index = chapter_index || annotation&.fetch('chapter_index')
         @cursor_pos = @note.length

--- a/lib/ebook_reader/terminal_mouse_patch.rb
+++ b/lib/ebook_reader/terminal_mouse_patch.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module EbookReader
-  module Terminal
+  # Extensions to Terminal for mouse support
+  class Terminal
     class << self
       # Enable mouse tracking
       def enable_mouse

--- a/spec/annotations/annotation_lifecycle_spec.rb
+++ b/spec/annotations/annotation_lifecycle_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Annotation lifecycle integration', fake_fs: true do
+  let(:epub_path) { '/book.epub' }
+  let(:config) do
+    instance_double(EbookReader::Config,
+                    view_mode: :single,
+                    page_numbering_mode: :absolute,
+                    line_spacing: :normal,
+                    highlight_quotes: false,
+                    show_page_numbers: false)
+  end
+  let(:chapter) do
+    EbookReader::Models::Chapter.new(number: '1', title: 'Ch1', lines: ['Sample line of text'], metadata: nil)
+  end
+  let(:doc) do
+    instance_double(EbookReader::EPUBDocument,
+                    title: 'Test',
+                    chapters: [chapter],
+                    chapter_count: 1,
+                    language: 'en')
+  end
+
+  before do
+    allow(EbookReader::EPUBDocument).to receive(:new).and_return(doc)
+    allow(doc).to receive(:get_chapter).and_return(chapter)
+    allow(EbookReader::BookmarkManager).to receive(:get).and_return([])
+    allow(EbookReader::ProgressManager).to receive(:load).and_return(nil)
+    allow(EbookReader::ProgressManager).to receive(:save)
+    allow_any_instance_of(EbookReader::Reader).to receive(:set_message)
+  end
+
+  it 'allows creating, updating, and deleting annotations with persistence' do
+    reader = EbookReader::Reader.new(epub_path, config)
+    allow(reader).to receive(:extract_selected_text).and_return('selected text')
+
+    # Simulate selecting text and choosing Create Annotation from popup menu
+    reader.handle_mouse_input("\e[<0;11;5M")   # press at (10,4)
+    reader.handle_mouse_input("\e[<32;15;5M")  # drag to (14,4)
+    reader.handle_mouse_input("\e[<0;15;5m")   # release to finish selection
+    menu = reader.instance_variable_get(:@popup_menu)
+    expect(menu).not_to be_nil
+    expect(menu.visible).to be true
+    reader.handle_mouse_input("\e[<0;16;6m")   # click first menu item
+
+    editor = reader.instance_variable_get(:@current_mode)
+    expect(editor).to be_a(EbookReader::ReaderModes::AnnotationEditorMode)
+
+    %w[N o t e].each { |ch| editor.handle_input(ch) }
+    editor.handle_input("\x13") # Ctrl+S save
+
+    annotations = EbookReader::Annotations::AnnotationStore.get(epub_path)
+    expect(annotations.length).to eq(1)
+    expect(annotations.first['note']).to eq('Note')
+
+    # Reload reader to verify persistence and perform update
+    reader2 = EbookReader::Reader.new(epub_path, config)
+    reader2.switch_mode(:annotations)
+    list_mode = reader2.instance_variable_get(:@current_mode)
+    expect(list_mode.instance_variable_get(:@annotations).length).to eq(1)
+
+    list_mode.handle_input("\r")
+    editor2 = reader2.instance_variable_get(:@current_mode)
+    editor2.handle_input('!')
+    editor2.handle_input("\x13")
+    annotations = EbookReader::Annotations::AnnotationStore.get(epub_path)
+    expect(annotations.first['note']).to eq('Note!')
+
+    # Delete annotation
+    reader2.switch_mode(:annotations)
+    list_mode = reader2.instance_variable_get(:@current_mode)
+    list_mode.handle_input('d')
+    expect(EbookReader::Annotations::AnnotationStore.get(epub_path)).to be_empty
+
+    # Reload to confirm deletion persisted
+    reader3 = EbookReader::Reader.new(epub_path, config)
+    reader3.switch_mode(:annotations)
+    list_mode = reader3.instance_variable_get(:@current_mode)
+    expect(list_mode.instance_variable_get(:@annotations)).to be_empty
+  end
+end

--- a/spec/annotations/annotation_store_spec.rb
+++ b/spec/annotations/annotation_store_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EbookReader::Annotations::AnnotationStore, fake_fs: true do
+  let(:epub_path) { '/books/book.epub' }
+  let(:range) { { 'start' => { 'x' => 0, 'y' => 0 }, 'end' => { 'x' => 1, 'y' => 0 } } }
+
+  it 'adds and retrieves annotations' do
+    described_class.add(epub_path, 'quote', 'note', range, 1)
+    annotations = described_class.get(epub_path)
+    expect(annotations.length).to eq(1)
+    expect(annotations.first['text']).to eq('quote')
+  end
+
+  it 'updates an existing annotation' do
+    described_class.add(epub_path, 'quote', 'note', range, 1)
+    id = described_class.get(epub_path).first['id']
+    described_class.update(epub_path, id, 'new note')
+    annotations = described_class.get(epub_path)
+    expect(annotations.first['note']).to eq('new note')
+  end
+
+  it 'deletes an annotation' do
+    described_class.add(epub_path, 'quote', 'note', range, 1)
+    id = described_class.get(epub_path).first['id']
+    described_class.delete(epub_path, id)
+    expect(described_class.get(epub_path)).to be_empty
+  end
+end

--- a/spec/annotations/mouse_handler_spec.rb
+++ b/spec/annotations/mouse_handler_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EbookReader::Annotations::MouseHandler do
+  let(:handler) { described_class.new }
+
+  describe '#parse_mouse_event' do
+    it 'parses valid events' do
+      event = handler.parse_mouse_event("\e[<0;10;5M")
+      expect(event).to eq(button: 0, x: 9, y: 4, released: false)
+    end
+
+    it 'returns nil for invalid data' do
+      expect(handler.parse_mouse_event('abc')).to be_nil
+    end
+  end
+
+  describe 'selection lifecycle' do
+    it 'tracks selection from press to release' do
+      handler.handle_event(button: 0, x: 1, y: 2, released: false)
+      handler.handle_event(button: 32, x: 3, y: 2, released: false)
+      handler.handle_event(button: 0, x: 3, y: 2, released: true)
+      range = handler.selection_range
+      expect(range[:start]).to eq(x:1, y:2)
+      expect(range[:end]).to eq(x:3, y:2)
+      handler.reset
+      expect(handler.selection_range).to be_nil
+    end
+  end
+end

--- a/spec/ui/components/popup_menu_spec.rb
+++ b/spec/ui/components/popup_menu_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EbookReader::UI::Components::PopupMenu do
+  let(:menu) { described_class.new(5, 5, ['One', 'Two']) }
+
+  it 'tracks selected item with keyboard navigation' do
+    expect(menu.get_selected_item).to eq('One')
+    menu.move_selection(1)
+    expect(menu.get_selected_item).to eq('Two')
+  end
+
+  it 'detects clicks inside its bounds' do
+    item = menu.handle_click(6, 5)
+    expect(item).to eq('One')
+    expect(menu.selected_index).to eq(0)
+  end
+
+  it 'returns nil for clicks outside bounds' do
+    expect(menu.handle_click(0, 0)).to be_nil
+  end
+end


### PR DESCRIPTION
## Summary
- Fix Terminal mouse patch by reopening the correct class to avoid startup TypeError
- Add RSpec coverage for annotation store, mouse handler, popup menu, and full annotation lifecycle
- Make annotation editor strings mutable to allow note editing

## Testing
- `bundle exec rspec spec/annotations spec/ui/components/popup_menu_spec.rb`


------
https://chatgpt.com/codex/tasks/task_e_68918af5ec94832bbb4e108f184df56e